### PR TITLE
Add missing webpack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ var config = {
   },
   output: {
     path: __dirname + '/dist', // `dist` is the destination
+    publicPath: "/assets/",
     filename: '[name].bundle.js',
   },
 };


### PR DESCRIPTION
The output object was missing the publicPath key-value pair. Because of this the webpack-dev-server could not serve the bundle file. The added publicPath fixes the issue of serving the bundle.js file